### PR TITLE
chore(ci): improve coverage file processing for multiple test projects

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -75,7 +75,7 @@ jobs:
       - name: 🧪 Run unit tests with coverage
         run: |
           mkdir -p TestResults
-          mkdir -p coverage
+          mkdir -p Coverage
 
           # Run all tests with coverage and collect results
           dotnet test ./finnhub-mcp.sln \
@@ -88,25 +88,40 @@ jobs:
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute=GeneratedCodeAttribute
 
-      - name: 📂 Move coverage files
+      - name: 📂 Process coverage files
         run: |
-          # Find and move coverage files to a consistent location
-          find ./TestResults -name "coverage.cobertura.xml" -exec cp {} ./coverage/ \;
-          # Also copy any .trx files
+          # Create coverage directory
+          mkdir -p ./Coverage
+
+          # Find all coverage files in GUID directories and rename them uniquely
+          counter=1
+          for file in $(find ./TestResults -path "*/*/coverage.cobertura.xml"); do
+            # Extract the GUID directory name for identification
+            guid=$(basename $(dirname "$file"))
+            cp "$file" "./coverage/coverage-${guid}.cobertura.xml"
+            echo "Copied $file to ./coverage/coverage-${guid}.cobertura.xml"
+            ((counter++))
+          done
+
+          # Copy test results file
           find ./TestResults -name "*.trx" -exec cp {} ./coverage/ \;
+
+          # Show what we have
+          echo "Files in coverage directory:"
+          ls -la ./coverage/
 
       - name: 📂 Show coverage and test files
         run: |
           echo "Coverage files:"
-          find ./coverage -name "*.xml" -o -name "*.trx"
-          echo "TestResults directory:"
+          find ./Coverage -name "*.xml" -o -name "*.trx"
+          echo "TestResults files:"
           find ./TestResults -type f
 
       - name: 📤 Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/coverage.cobertura.xml
+          files: ./coverage/*.cobertura.xml
           flags: unit-tests
           name: codecov-finnhub-mcp
           fail_ci_if_error: true
@@ -136,4 +151,4 @@ jobs:
           name: test-results
           path: |
             ./TestResults/
-            ./coverage/
+            ./Coverage/


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [x] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR improve coverage file processing for multiple test projects

### Checklist

- [ ] Update coverage file handling to use GUID-based naming from test runner output
- [ ] Change find pattern to target specific GUID directory structure (`*/*/coverage.cobertura.xml`)
- [ ] Use GUID as file identifier instead of sequential numbering for better traceability
- [ ] Add debugging output to show processed files in coverage directory
- [ ] Update `Codecov` upload to use wildcard pattern for multiple coverage files
- [ ] Resolves issue where multiple `coverage.cobertura.xml` files were overwriting each other

### GitHub Links

Closes #92 

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [x] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
